### PR TITLE
Adding typescript packages to devDependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,15 +6,17 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.63",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
-    "typescript": "^4.8.4",
-    "web-vitals": "^2.1.4"
+    "typescript": "^4.8.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Typescript and "@types" packages are not used in production build.